### PR TITLE
Encode macros correctly

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -155,6 +155,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 	double old_latency = 0.0;
 	check_result *cr;
 	int runchk_result = OK;
+	int macro_options = STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS;
 #ifdef USE_EVENT_BROKER
 	int neb_result = OK;
 #endif
@@ -222,7 +223,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 	grab_service_macros_r(&mac, svc);
 
 	/* get the raw command line */
-	get_raw_command_line_r(&mac, svc->check_command_ptr, svc->check_command, &raw_command, 0);
+	get_raw_command_line_r(&mac, svc->check_command_ptr, svc->check_command, &raw_command, macro_options);
 	if(raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Raw check command for service '%s' on host '%s' was NULL - aborting.\n", svc->description, svc->host_name);
@@ -233,7 +234,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 		}
 
 	/* process any macros contained in the argument */
-	process_macros_r(&mac, raw_command, &processed_command, 0);
+	process_macros_r(&mac, raw_command, &processed_command, macro_options);
 	my_free(raw_command);
 	if(processed_command == NULL) {
 		clear_volatile_macros_r(&mac);
@@ -2060,6 +2061,7 @@ int execute_sync_host_check(host *hst) {
 	int early_timeout = FALSE;
 	double exectime;
 	char *temp_plugin_output = NULL;
+	int macro_options = STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS;
 #ifdef USE_EVENT_BROKER
 	int neb_result = OK;
 #endif
@@ -2109,14 +2111,14 @@ int execute_sync_host_check(host *hst) {
 	time(&hst->last_check);
 
 	/* get the raw command line */
-	get_raw_command_line_r(&mac, hst->check_command_ptr, hst->check_command, &raw_command, 0);
+	get_raw_command_line_r(&mac, hst->check_command_ptr, hst->check_command, &raw_command, macro_options);
 	if(raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
 		}
 
 	/* process any macros contained in the argument */
-	process_macros_r(&mac, raw_command, &processed_command, 0);
+	process_macros_r(&mac, raw_command, &processed_command, macro_options);
 	if(processed_command == NULL) {
 		my_free(raw_command);
 		clear_volatile_macros_r(&mac);
@@ -2302,6 +2304,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 	double old_latency = 0.0;
 	check_result *cr;
 	int runchk_result = OK;
+	int macro_options = STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS;
 #ifdef USE_EVENT_BROKER
 	int neb_result = OK;
 #endif
@@ -2365,7 +2368,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 	grab_host_macros_r(&mac, hst);
 
 	/* get the raw command line */
-	get_raw_command_line_r(&mac, hst->check_command_ptr, hst->check_command, &raw_command, 0);
+	get_raw_command_line_r(&mac, hst->check_command_ptr, hst->check_command, &raw_command, macro_options);
 	if(raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Raw check command for host '%s' was NULL - aborting.\n", hst->name);
@@ -2373,7 +2376,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		}
 
 	/* process any macros contained in the argument */
-	process_macros_r(&mac, raw_command, &processed_command, 0);
+	process_macros_r(&mac, raw_command, &processed_command, macro_options);
 	my_free(raw_command);
 	if(processed_command == NULL) {
 		clear_volatile_macros_r(&mac);

--- a/common/macros.c
+++ b/common/macros.c
@@ -38,7 +38,6 @@ char *macro_user[MAX_USER_MACROS]; /* $USERx$ macros */
 struct macro_key_code {
 	char *name; /* macro key name */
 	int code;  /* numeric macro code, usable in case statements */
-	int clean_options;
 	char *value;
 };
 
@@ -110,9 +109,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 	char *selected_macro = NULL;
 	char *original_macro = NULL;
 	int result = OK;
-	int clean_options = 0;
 	int free_macro = FALSE;
-	int macro_options = 0;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "process_macros_r()\n");
 
@@ -164,13 +161,10 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 		/* looks like we're in a macro, so process it... */
 		else {
 
-			/* reset clean options */
-			clean_options = 0;
-
 			/* grab the macro value */
 			free_macro = FALSE;
-			result = grab_macro_value_r(mac, temp_buffer, &selected_macro, &clean_options, &free_macro);
-			log_debug_info(DEBUGL_MACROS, 2, "  Processed '%s', Clean Options: %d, Free: %d\n", temp_buffer, clean_options, free_macro);
+			result = grab_macro_value_r(mac, temp_buffer, &selected_macro, NULL, &free_macro);
+			log_debug_info(DEBUGL_MACROS, 2, "  Processed '%s', Free: %d\n", temp_buffer, free_macro);
 
 			/* an error occurred - we couldn't parse the macro, so continue on */
 			if(result == ERROR) {
@@ -201,15 +195,10 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 
 			/* insert macro */
 			if(selected_macro != NULL) {
-				log_debug_info(DEBUGL_MACROS, 2, "  Processed '%s', Clean Options: %d, Free: %d\n", temp_buffer, clean_options, free_macro);
-
-				/* include any cleaning options passed back to us */
-				macro_options = (options | clean_options);
-
-				log_debug_info(DEBUGL_MACROS, 2, "  Cleaning options: global=%d, local=%d, effective=%d\n", options, clean_options, macro_options);
+				log_debug_info(DEBUGL_MACROS, 2, "  Processed '%s', Free: %d,  Cleaning options: %d\n", temp_buffer, free_macro, options);
 
 				/* URL encode the macro if requested - this allocates new memory */
-				if(macro_options & URL_ENCODE_MACRO_CHARS) {
+				if(options & URL_ENCODE_MACRO_CHARS) {
 					original_macro = selected_macro;
 					selected_macro = get_url_encoded_string(selected_macro);
 					if(free_macro == TRUE) {
@@ -219,11 +208,11 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 					}
 
 				/* some macros are cleaned... */
-				if(macro_options & STRIP_ILLEGAL_MACRO_CHARS || macro_options & ESCAPE_MACRO_CHARS) {
+				if((options & STRIP_ILLEGAL_MACRO_CHARS) || (options & ESCAPE_MACRO_CHARS)) {
 					char *cleaned_macro = NULL;
 
 					/* add the (cleaned) processed macro to the end of the already processed buffer */
-					if(selected_macro != NULL && (cleaned_macro = clean_macro_chars(selected_macro, macro_options)) != NULL) {
+					if(selected_macro != NULL && (cleaned_macro = clean_macro_chars(selected_macro, options)) != NULL) {
 						*output_buffer = (char *)realloc(*output_buffer, strlen(*output_buffer) + strlen(cleaned_macro) + 1);
 						strcat(*output_buffer, cleaned_macro);
 						if(*cleaned_macro)
@@ -413,7 +402,7 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 	/* clear the old macro value */
 	my_free(*output);
 
-	if(macro_buffer == NULL || clean_options == NULL || free_macro == NULL)
+	if(macro_buffer == NULL || free_macro == NULL)
 		return ERROR;
 
 
@@ -488,10 +477,6 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 
 	if ((mkey = find_macro_key(macro_name))) {
 		log_debug_info(DEBUGL_MACROS, 2, "  macros[%d] (%s) match.\n", mkey->code, macro_x_names[mkey->code]);
-		if (mkey->clean_options) {
-			*clean_options |= mkey->clean_options;
-			log_debug_info(DEBUGL_MACROS, 2, "  New clean options: %d\n", *clean_options);
-			}
 
 		/* get the macro value */
 		result = grab_macrox_value_r(mac, mkey->code, arg[0], arg[1], output, free_macro);
@@ -2389,12 +2374,6 @@ char *clean_macro_chars(char *macro, int options) {
 		ret[y++] = '\x0';
 		}
 
-#ifdef ON_HOLD_FOR_NOW
-	/* escape nasty character in macro */
-	if(options & ESCAPE_MACRO_CHARS) {
-		}
-#endif
-
 	return ret;
 	}
 
@@ -2402,6 +2381,32 @@ char *clean_macro_chars(char *macro, int options) {
 
 /* encodes a string in proper URL format */
 char *get_url_encoded_string(char *input) {
+	/* From RFC 3986:
+	segment       = *pchar
+
+	[...]
+
+	pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+
+	query         = *( pchar / "/" / "?" )
+
+	fragment      = *( pchar / "/" / "?" )
+
+	pct-encoded   = "%" HEXDIG HEXDIG
+
+	unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+	reserved      = gen-delims / sub-delims
+	gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+	                 / "*" / "+" / "," / ";" / "="
+
+	Encode everything but "unreserved", to be on safe side.
+
+	Another note:
+	nowhere in the RFC states that + is interpreted as space. Therefore, encode
+	space as %20 (as all other characters that should be escaped)
+	*/
+
 	register int x = 0;
 	register int y = 0;
 	char *encoded_url_string = NULL;
@@ -2420,14 +2425,14 @@ char *get_url_encoded_string(char *input) {
 	for(x = 0, y = 0; input[x] != (char)'\x0'; x++) {
 
 		/* alpha-numeric characters and a few other characters don't get encoded */
-		if(((char)input[x] >= '0' && (char)input[x] <= '9') || ((char)input[x] >= 'A' && (char)input[x] <= 'Z') || ((char)input[x] >= (char)'a' && (char)input[x] <= (char)'z') || (char)input[x] == (char)'.' || (char)input[x] == (char)'-' || (char)input[x] == (char)'_' || (char)input[x] == (char)':' || (char)input[x] == (char)'/' || (char)input[x] == (char)'?' || (char)input[x] == (char)'=' || (char)input[x] == (char)'&') {
+		if(		((char)input[x] >= '0' && (char)input[x] <= '9') ||
+				((char)input[x] >= 'A' && (char)input[x] <= 'Z') ||
+				((char)input[x] >= 'a' && (char)input[x] <= 'z') ||
+				(char)input[x] == '.' ||
+				(char)input[x] == '-' ||
+				(char)input[x] == '_' ||
+				(char)input[x] == '~') {
 			encoded_url_string[y] = input[x];
-			y++;
-			}
-
-		/* spaces are pluses */
-		else if((char)input[x] <= (char)' ') {
-			encoded_url_string[y] = '+';
 			y++;
 			}
 
@@ -2492,31 +2497,7 @@ int init_macros(void) {
 	for (x = 0; x < MACRO_X_COUNT; x++) {
 		macro_keys[x].code = x;
 		macro_keys[x].name = macro_x_names[x];
-		macro_keys[x].clean_options = 0;
-
-		switch (x) {
-			/* output, perfdata, comments and author names need cleaning */
-		case MACRO_HOSTOUTPUT: case MACRO_SERVICEOUTPUT:
-		case MACRO_HOSTPERFDATA: case MACRO_SERVICEPERFDATA:
-		case MACRO_HOSTACKAUTHOR: case MACRO_HOSTACKCOMMENT:
-		case MACRO_SERVICEACKAUTHOR: case MACRO_SERVICEACKCOMMENT:
-		case MACRO_LONGHOSTOUTPUT: case MACRO_LONGSERVICEOUTPUT:
-		case MACRO_HOSTGROUPNOTES: case MACRO_SERVICEGROUPNOTES:
-			macro_keys[x].clean_options = (STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
-			break;
-
-			/* url macros get url-encoded */
-		case MACRO_HOSTACTIONURL: case MACRO_HOSTNOTESURL:
-		case MACRO_SERVICEACTIONURL: case MACRO_SERVICENOTESURL:
-		case MACRO_HOSTGROUPNOTESURL: case MACRO_HOSTGROUPACTIONURL:
-		case MACRO_SERVICEGROUPNOTESURL: case MACRO_SERVICEGROUPACTIONURL:
-			macro_keys[x].clean_options = URL_ENCODE_MACRO_CHARS;
-			break;
-		default:
-			macro_keys[x].clean_options = 0;
-			break;
-			}
-		}
+	}
 
 	qsort(macro_keys, x, sizeof(struct macro_key_code), macro_key_cmp);
 	return OK;

--- a/t-tap/Makefile.in
+++ b/t-tap/Makefile.in
@@ -18,6 +18,7 @@ TESTS += test_checks
 TESTS += test_strtoul
 TESTS += test_commands
 TESTS += test_downtime
+TESTS += test_macros
 
 XSD_OBJS = $(SRC_CGI)/statusdata-cgi.o $(SRC_CGI)/xstatusdata-cgi.o
 XSD_OBJS += $(SRC_CGI)/objects-cgi.o $(SRC_CGI)/xobjects-cgi.o
@@ -113,6 +114,9 @@ test_nagios_config: test_nagios_config.o $(CFG_OBJS) $(TAPOBJ)
 
 test_timeperiods: test_timeperiods.o $(TP_OBJS) $(TAPOBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(BROKER_LDFLAGS) $(LDFLAGS) $(MATHLIBS) $(SOCKETLIBS) $(BROKERLIBS) $(LIBS)
+
+test_macros: test_macros.o $(TP_OBJS) $(TAPOBJ)
+	$(CC) $(CFLAGS) -o $@ $^ $(BROKER_LDFLAGS) $(LDFLAGS) $(MATHLIBS) $(SOCKETLIBS) $(LIBS)
 
 test_xsddefault: test_xsddefault.o $(XSD_OBJS) $(TAPOBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)

--- a/t-tap/test_macros.c
+++ b/t-tap/test_macros.c
@@ -1,0 +1,211 @@
+/*****************************************************************************
+ *
+ * test_macros.c - Test macro expansion and escaping
+ *
+ * Program: Nagios Core Testing
+ * License: GPL
+ *
+ * First Written:   2013-05-21
+ *
+ * Description:
+ *
+ * Tests expansion of macros and escaping.
+ *
+ * License:
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ *****************************************************************************/
+
+#include <string.h>
+#include "../include/objects.h"
+#include "../include/nagios.h"
+#include "tap.h"
+
+/*****************************************************************************/
+/*                             Dummy functions                               */
+/*****************************************************************************/
+void logit(int data_type, int display, const char *fmt, ...) {
+}
+int my_sendall(int s, char *buf, int *len, int timeout) {
+	return 0;
+}
+void free_comment_data(void) {
+}
+
+int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+	return 0;
+}
+
+int neb_free_callback_list(void) {
+	return 0;
+}
+
+int neb_deinit_modules(void) {
+	return 0;
+}
+void broker_program_state(int type, int flags, int attr,
+		struct timeval *timestamp) {
+}
+int neb_unload_all_modules(int flags, int reason) {
+	return 0;
+}
+int neb_add_module(char *filename, char *args, int should_be_loaded) {
+	return 0;
+}
+void broker_system_command(int type, int flags, int attr,
+		struct timeval start_time, struct timeval end_time, double exectime,
+		int timeout, int early_timeout, int retcode, char *cmd, char *output,
+		struct timeval *timestamp) {
+}
+
+timed_event *schedule_new_event(int event_type, int high_priority,
+		time_t run_time, int recurring, unsigned long event_interval,
+		void *timing_func, int compensate_for_time_change, void *event_data,
+		void *event_args, int event_options) {
+	return NULL ;
+}
+int my_tcp_connect(char *host_name, int port, int *sd, int timeout) {
+	return 0;
+}
+int my_recvall(int s, char *buf, int *len, int timeout) {
+	return 0;
+}
+int neb_free_module_list(void) {
+	return 0;
+}
+int close_command_file(void) {
+	return 0;
+}
+int close_log_file(void) {
+	return 0;
+}
+int fix_log_file_owner(uid_t uid, gid_t gid) {
+	return 0;
+}
+int handle_async_service_check_result(service *temp_service,
+		check_result *queued_check_result) {
+	return 0;
+}
+int handle_async_host_check_result(host *temp_host,
+		check_result *queued_check_result) {
+	return 0;
+}
+
+/*****************************************************************************/
+/*                             Local test environment                        */
+/*****************************************************************************/
+
+host test_host = { .name = "name'&%", .address = "address'&%", .notes_url =
+		"notes_url'&%($HOSTNOTES$)", .notes = "notes'&%($HOSTACTIONURL$)",
+		.action_url = "action_url'&%" };
+
+/*****************************************************************************/
+/*                             Helper functions                              */
+/*****************************************************************************/
+
+void init_environment() {
+	char *p;
+
+	my_free(illegal_output_chars);
+	illegal_output_chars = strdup("'&"); /* For this tests, remove ' and & */
+
+	/* This is a part of preflight check, which we can't run */
+	for (p = illegal_output_chars; *p; p++) {
+		illegal_output_char_map[(int) *p] = 1;
+	}
+}
+
+nagios_macros *setup_macro_object(void) {
+	nagios_macros *mac = (nagios_macros *) calloc(1, sizeof(nagios_macros));
+	grab_host_macros_r(mac, &test_host);
+	return mac;
+}
+
+#define RUN_MACRO_TEST(_STR, _EXPECT, _OPTS) \
+	do { \
+		if( OK == process_macros_r(mac, (_STR), &output, _OPTS ) ) {\
+			ok( 0 == strcmp( output, _EXPECT ), "'%s': '%s' == '%s'", (_STR), output, (_EXPECT) ); \
+		} else { \
+			fail( "process_macros_r returns ERROR for " _STR ); \
+		} \
+	} while(0)
+
+/*****************************************************************************/
+/*                             Tests                                         */
+/*****************************************************************************/
+
+void test_escaping(nagios_macros *mac) {
+	char *output;
+
+	/* Nothing should be changed... options == 0 */
+	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name'&% '&%", 0);
+
+	/* ' and & should be stripped from the macro, according to
+	 * init_environment(), but not from the initial string
+	 */
+	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name% '&%", STRIP_ILLEGAL_MACRO_CHARS);
+
+	/* ESCAPE_MACRO_CHARS doesn't seem to do anything... exist always in pair
+	 * with STRIP_ILLEGAL_MACRO_CHARS
+	 */
+	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name'&% '&%", ESCAPE_MACRO_CHARS);
+	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name% '&%",
+			STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
+
+	/* $HOSTNAME$ should be url-encoded, but not the tailing chars */
+	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name%27%26%25 '&%",
+			URL_ENCODE_MACRO_CHARS);
+
+	/* The notes in the notesurl should be url-encoded, no more encoding should
+	 * exist
+	 */
+	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
+			"notes_url'&%(notes%27%26%25%28action_url%27%26%25%29) '&%", 0);
+
+	/* '& in the source string should be removed, as in the url. the macros
+	 * included in the string should be url-encoded, and therefore not contain &
+	 * and '
+	 */
+	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
+			"notes_url%(notes%27%26%25%28action_url%27%26%25%29) '&%",
+			STRIP_ILLEGAL_MACRO_CHARS);
+
+	/* This should double-encode some chars ($HOSTNOTESURL$ should contain
+	 * url-encoded chars, and should itself be url-encoded
+	 */
+	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
+			"notes_url%27%26%25%28notes%2527%2526%2525%2528action_url%2527%2526%2525%2529%29 '&%",
+			URL_ENCODE_MACRO_CHARS);
+}
+
+/*****************************************************************************/
+/*                             Main function                                 */
+/*****************************************************************************/
+
+int main(void) {
+	nagios_macros *mac;
+
+	reset_variables();
+	init_environment();
+	init_macros();
+
+	mac = setup_macro_object();
+
+	test_escaping(mac);
+
+	cleanup();
+	free(mac);
+	return exit_status();
+}


### PR DESCRIPTION
Sending this pull request so the code can be reviewed and discussed before tests is written.

The encoding of macros was earlier made by looking at two things:
- The target of the string the macro was put in (url, command line, note)
- Which macro was going to be expanded (url, command line argument, note)

The only thing deciding how to escape is actually the first one; putting an url in a notes-field shouldn't url-encode the url again, just because it's a url.

A side effect of this was that the url-encode routine whitelisted to many characters, so the url didn't got broken to much, so double escaping worked most of the time.

This has an impact on the routines calling the macro escaping: those routinges needs to be picky about actually asking for the correct escaping; macros isn't command-line-escaped by default, and the bug auto-escaping those (because most argument types says they should be command-line-escaped). The code sending notifications indicates that this was the original though (by passing those arguments to the macro expansion routine). The check execution is patched in this pull request.

The same effect affects third party broker modules using the macro expansion code. Two modules is found to have this problem; op5 testthis, but this is patched in the master, but doesn't have a version number yet. And also mod_gearman is affected.
