### PR TITLE
base/workers.c: fixed return code on wproc_run_job()

### DIFF
--- a/base/workers.c
+++ b/base/workers.c
@@ -909,14 +909,17 @@ static int wproc_run_job(struct wproc_job *job, nagios_macros *mac)
 	kvvec_addkv(&kvv, "timeout", (char *)mkstr("%u", job->timeout));
 	kvvb = build_kvvec_buf(&kvv);
 	ret = write(wp->sd, kvvb->buf, kvvb->bufsize);
-	wp->jobs_running++;
-	wp->jobs_started++;
-	loadctl.jobs_running++;
 	if (ret != (int)kvvb->bufsize) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "wproc: '%s' seems to be choked. ret = %d; bufsize = %lu: errno = %d (%s)\n",
 			  wp->name, ret, kvvb->bufsize, errno, strerror(errno));
 		destroy_job(job);
+		free(kvvb->buf);
+		free(kvvb);
+		return ERROR;
 	}
+	wp->jobs_running++;
+	wp->jobs_started++;
+	loadctl.jobs_running++;
 	free(kvvb->buf);
 	free(kvvb);
 


### PR DESCRIPTION
in case of errors, write(2) may return 0, that may
be interpreted as OK on caller. also, we only increase
jobs_running and jobs_started on worker process if
write succeded.

loadct.jobs_running also is incremented only if
we sucessfuly submitted the job.
